### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 ## Requirements
 * Swift 3
 * Xcode 8
-* Cocoapods 1.0.1
+* CocoaPods 1.0.1
 
 ## Dependencies
 * VideoCore


### PR DESCRIPTION

This pull request corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
